### PR TITLE
Fixed typos, grammar and broken hyperlink.

### DIFF
--- a/pages/learning-labs/jte-advanced-features/2-default-step-implementation.rst
+++ b/pages/learning-labs/jte-advanced-features/2-default-step-implementation.rst
@@ -258,4 +258,4 @@ default step implementation here: ``[JTE] [Step - Default Step Implementation/un
 
 When the step executed, it checked if the ``maven`` step was available locally and pulls the image if not. 
 
-Within it container image, it then ran ``mvn -v`` and the maven version was printed to the build log. 
+Within the container image, it then ran ``mvn -v`` and the maven version was printed to the build log.

--- a/pages/learning-labs/jte-advanced-features/3-pipeline-lifecycle-hooks.rst
+++ b/pages/learning-labs/jte-advanced-features/3-pipeline-lifecycle-hooks.rst
@@ -4,11 +4,11 @@
 Pipeline Lifecycle Hooks 
 ------------------------
 
-There can be interdependent functionalities that presented a challenge to the 
-Jenkins Templating Engine.  
+There can be interdependent functionalities that present a challenge to the
+Jenkins Templating Engine.
 
 For example, let's say we wanted to introduce Splunk monitoring by sending events 
-as part of the pipeline? 
+as part of the pipeline.
 
 How do you: 
 
@@ -458,7 +458,7 @@ Update the ``@AfterStep`` Annotation
 
 Let's see it in action. 
 
-Update the ``@AfterStep`` created in **libraries/splunk/pipeline_step_watcher.groovy** to: 
+Update the ``@AfterStep`` created in **libraries/splunk/splunk_step_watcher.groovy** to:
 
 .. code:: groovy 
 
@@ -510,5 +510,5 @@ Run the pipeline again and notice that the hook was only executed after the step
     As long as the Closure returns a non-false value, the hook will be invoked. 
 
 
-**Remember to read through the `Pipeline Lifecycle Hook documentation <https://jenkinsci.github.io/templating-engine-plugin/pages/Library_Development/lifecycle_hooks.html>`_ 
-to see all the annotations available.**
+**Remember to read through the** `Pipeline Lifecycle Hook documentation <https://jenkinsci.github.io/templating-engine-plugin/pages/Library_Development/lifecycle_hooks.html>`_
+**to see all the annotations available**.

--- a/pages/learning-labs/jte-advanced-features/4-multimethod-steps.rst
+++ b/pages/learning-labs/jte-advanced-features/4-multimethod-steps.rst
@@ -28,7 +28,7 @@ When to use Multi-Method Steps
 The most common use case for defining multiple methods inside one step file is when you're 
 creating some utility functionality. 
 
-To demonstrate this, let's create a mock ``git`` utility that can ``add`, ``commit``, and 
+To demonstrate this, let's create a mock ``git`` utility that can ``add``, ``commit``, and
 ``push``. 
 
 ======================

--- a/pages/learning-labs/jte-primitives/4-application-environments.rst
+++ b/pages/learning-labs/jte-primitives/4-application-environments.rst
@@ -10,7 +10,7 @@ What is an Application Environment?
 
 Performing an automated deployment is a ubiquitious step in continuous delivery pipelines. 
 
-Libraries can implement steps to perform deployments and when doing so, need a mechanism to 
+Libraries can implement steps to perform deployments and, when doing so, need a mechanism to
 tell the deployment step which application environment is being deployed to. 
 
 The Application Environment acts to encapsulate the contextual information that identifies 
@@ -151,8 +151,8 @@ Update the **Pipeline Configuration** to:
     variable will be made available in the pipeline template based upon this name. 
 
     The only two keys that Application Environments explicitly define are ``short_name`` 
-    and ``long_name``.  These values default to the key defininig the Application Environment 
-    in the Pipelien Configuration, but can be overridden. 
+    and ``long_name``.  These values default to the key defining the Application Environment
+    in the Pipeline Configuration, but can be overridden.
 
 ****************************
 Update the Pipeline Template

--- a/pages/learning-labs/jte-the-basics/7-github-org.rst
+++ b/pages/learning-labs/jte-the-basics/7-github-org.rst
@@ -26,7 +26,7 @@ to create a maven application repository named ``jte-the-basics-app-maven``.
 Modify the Pipeline Configurations
 ==================================
 
-Now that there are multiple applications with some configurations are common 
+Now that there are multiple applications with some configurations that are common
 and some configurations that are unique, we need to introduce the concept of 
 pipeline configuration aggregation. 
 

--- a/pages/learning-labs/jte-the-basics/8-summary.rst
+++ b/pages/learning-labs/jte-the-basics/8-summary.rst
@@ -42,7 +42,7 @@ We learned that:
 2.  Pipeline Templates are responsible for the **business logic** of your pipeline
 3.  Libraries are responsible for the **technical implementation** of your pipeline 
 4.  Pipeline Configuration Files **implement** a template by specifying (among other things) what libraries to load
-4.  When stored in a repo, Pipeline Configuration Files are called ``pipeline_config.groovy`` and are located at the root of the repository
+5.  When stored in a repo, Pipeline Configuration Files are called ``pipeline_config.groovy`` and are located at the root of the repository
 
 ==========================
 What is a Governance Tier?


### PR DESCRIPTION
# PR Details

Fixed typos, grammar/tense, incorrect filename and a broken hyperlink.

## Description

* The hyperlink was broken because of the surrounding bold text. I moved the bolding to the individual text outside of the hyperlink text.
* One `AfterStep` direction referenced an incorrect filename. Changed to match the filename introduced at the beginning of the section.
* Fixed an ordered-list item being incorrectly out of the list.

## Types of Changes

<!--- What types of changes does your code introduce? Change [ ] to [x] for all boxes that apply: -->

- [x] Fixing spelling errors 
- [ ] Adding a new Learning Lab 
- [x] Updating content to improve clarity 
- [x] This Pull Request does not contain changes to the static HTML in the ``docs`` directory 

