### PR TITLE
Updating local dev instructions for Windows

### DIFF
--- a/learning-labs/modules/local-development/pages/2-run-jenkins.adoc
+++ b/learning-labs/modules/local-development/pages/2-run-jenkins.adoc
@@ -4,7 +4,7 @@ Docker simplifies packaging applications with all their dependencies.
 
 Through Docker, we can have a running Jenkins instance in a matter of seconds. 
 
-In your terminal, run: <br />
+In your terminal, run: 
 
 (If running Docker for Windows, please refer to Important section below)
 
@@ -64,7 +64,7 @@ If port 8080 is already in use by another process then this command will fail.  
 
 [IMPORTANT]
 ====
-Windows OS: When using Docker for Windows, use the following command to run the Jenkins container: <br />
+Windows OS: When using Docker for Windows, use the following command to run the Jenkins container: 
 docker run --name jenkins -v /usr/local/bin/docker:/usr/bin/docker -v //var/run/docker.sock:/var/run/docker.sock --privileged --user root -p 50000:50000 -p 8080:8080 -d jenkins/jenkins:lts
 
 You can run ``docker logs -f jenkins`` to see the Jenkins logs.  It will say "Jenkins is fully up and running" when Jenkins is ready.

--- a/learning-labs/modules/local-development/pages/2-run-jenkins.adoc
+++ b/learning-labs/modules/local-development/pages/2-run-jenkins.adoc
@@ -4,7 +4,9 @@ Docker simplifies packaging applications with all their dependencies.
 
 Through Docker, we can have a running Jenkins instance in a matter of seconds. 
 
-In your terminal, run: 
+In your terminal, run: <br />
+
+(If running Docker for Windows, please refer to Important section below)
 
 [source,]
 ----
@@ -62,7 +64,11 @@ If port 8080 is already in use by another process then this command will fail.  
 
 [IMPORTANT]
 ====
+Windows OS: When using Docker for Windows, use the following command to run the Jenkins container: <br />
+docker run --name jenkins -v /usr/local/bin/docker:/usr/bin/docker -v //var/run/docker.sock:/var/run/docker.sock --privileged --user root -p 50000:50000 -p 8080:8080 -d jenkins/jenkins:lts
+
 You can run ``docker logs -f jenkins`` to see the Jenkins logs.  It will say "Jenkins is fully up and running" when Jenkins is ready.
+
 ====
 
 You can validate the container launched as expected by going to ``http://localhost:8080``. 


### PR DESCRIPTION
Command listed in tutorial is not applicable to Windows OS. Appropriate command was added in the Important section

# PR Details

When running the original tutorial command in Windows OS, Jenkins container will not run correctly as it can't build docker containers.

## Description

Added command in tutorial to allow correct Jenkins container for Windows OS.

## Types of Changes


- [ ] Fixing spelling errors 
- [ ] Adding a new Learning Lab 
- [x ] Updating content to improve clarity 
- [ ] This Pull Request does not contain changes to the static HTML in the ``docs`` directory 

