### PR TITLE
Updated to reference 'pipeline configuration' section under JTE

### DIFF
--- a/learning-labs/modules/jte-primitives/pages/1-prerequisites.adoc
+++ b/learning-labs/modules/jte-primitives/pages/1-prerequisites.adoc
@@ -19,7 +19,7 @@ If this is still configured, remove it.
 . From the Jenkins homepage, Click `Manage Jenkins` in the lefthand navigation menu
 . Click `Configure System`
 . Scroll down to the `Jenkins Templating Engine` configuration section
-. For the `Source Location` dropdown menu, select `None`
+. Under `Pipeline Configuration` dropdown menu, select `None`
 . Remove any text in the `Configuration Base Directory` text box
 . Click `Save`
 


### PR DESCRIPTION
added missing instruction for 'Pipeline Configuration'
Updated to reference 'pipeline configuration' section under JTE

added missing instruction for 'Pipeline Configuration'
Updated to reference 'pipeline configuration' section under JTE

added missing instruction for 'Pipeline Configuration'

## Types of Changes

- [ ] Fixing spelling errors 
- [ ] Adding a new Learning Lab 
- [x ] Updating content to improve clarity 
- [ ] This Pull Request does not contain changes to the static HTML in the ``docs`` directory 

