### PR TITLE
Update 3-configure-jenkins.adoc

### DIFF
--- a/learning-labs/modules/local-development/pages/3-configure-jenkins.adoc
+++ b/learning-labs/modules/local-development/pages/3-configure-jenkins.adoc
@@ -93,3 +93,14 @@ At this point, Jenkins will restart automatically. Log in again with either the 
 ====
 You can run `docker logs -f jenkins` to see the Jenkins logs. It will say "Jenkins is fully up and running" when Jenkins has completed the restart and is ready to be interacted with.
 ====
+
+== Installing the Docker Pipeline plugin
+
+Now, we need to install the Docker Pipeline plugin, which can be found as the `Docker Pipeline` in the Jenkins Update Center.
+
+. In the lefthand navigation menu, select _Manage Jenkins_
+. In the middle of the screen, Select _Manage Plugins_
+. Select the _Available_ tab at the top
+. In the upper right _Filter_ text box, type: `Docker Pipeline`
+
+Follow the same steps used for installing the jenkins templating engine and restart the Jenkins instance.


### PR DESCRIPTION

# Add steps to install docker pipeline plugin

<!--- Provide a general summary of your changes in the Title above -->

## Description

When running through the documented steps I received the following error during my first build for the validate job:
  "No such property: docker for class: script1592226793672363440564"
Discovered that this resulted from not having the docker pipeline plugin installed in jenkins. Once installed, the validate job completed successfully. I ran through the steps from scratch and did not see this plugin included in the jenkins suggested plugins.

<!--- Describe your changes in detail -->

## Types of Changes

<!--- What types of changes does your code introduce? Change [ ] to [x] for all boxes that apply: -->

- [ ] Fixing spelling errors 
- [ ] Adding a new Learning Lab 
- [x] Updating content to improve clarity 
- [ ] This Pull Request does not contain changes to the static HTML in the ``docs`` directory 

