### PR TITLE
Fix typo in "JTE: The Basics" index

### DIFF
--- a/learning-labs/modules/jte-the-basics/pages/index.adoc
+++ b/learning-labs/modules/jte-the-basics/pages/index.adoc
@@ -16,6 +16,6 @@ The modularity that JTE promotes allows you to do this across teams _regardless_
 * Configure your first tool-agnostic pipeline template
 * Create your first set of pipeline libraries to provide tool-specific implementations of steps
 * Create your first pipeline configuration file that implements the template
-* Learn the difference types of jobs available in Jenkins and when to use them
+* Learn the different types of jobs available in Jenkins and when to use them
 * Learn how to take the Jenkinsfile (pipeline template) *out* of the repository
 * Learn how to consolidate pipeline configurations and apply the same template across multiple repositories


### PR DESCRIPTION
# PR Details

Addressing issue in Issue #24 

## Description

Changed bullet "Learn the difference types of jobs available in Jenkins and when to use them" to "Learn the different types of jobs available in Jenkins and when to use them"

## Types of Changes

<!--- What types of changes does your code introduce? Change [ ] to [x] for all boxes that apply: -->

- [x] Fixing spelling errors 
- [ ] Adding a new Learning Lab 
- [ ] Updating content to improve clarity 
- [ ] This Pull Request does not contain changes to the static HTML in the ``docs`` directory 

