### PR TITLE
Update local installation docs to add docker during image build

### DIFF
--- a/learning-labs/modules/local-development/pages/2-run-jenkins.adoc
+++ b/learning-labs/modules/local-development/pages/2-run-jenkins.adoc
@@ -80,7 +80,7 @@ Then, to start jenkins, run:
 | -d
 | Runs the container process in the background
 
-| jenkins/jenkins:lts
+| jenkins:lts-docker
 | The container image from which to run this container
 
 |===

--- a/learning-labs/modules/local-development/pages/2-run-jenkins.adoc
+++ b/learning-labs/modules/local-development/pages/2-run-jenkins.adoc
@@ -33,7 +33,7 @@ docker build -t jenkins:lts-docker .
 
 [NOTE]
 ====
-Running Jenkins as a docker container on a BAH managed machine requires specific certificates and tooling to be installed. A Dockerfile meeting these requirements can be built from the solutions-delivery-platform/bah-jenkins repo available internally.
+Running Jenkins as a docker container on a BAH managed machine requires specific certificates and tooling to be installed. A Dockerfile meeting these requirements can be built from the https://github.boozallencsn.com/solutions-delivery-platform/bah-jenkins[solutions-delivery-platform/bah-jenkins] repo.
 ====
 
 Then, to start jenkins, run:

--- a/learning-labs/modules/local-development/pages/2-run-jenkins.adoc
+++ b/learning-labs/modules/local-development/pages/2-run-jenkins.adoc
@@ -4,21 +4,52 @@ Docker simplifies packaging applications with all their dependencies.
 
 Through Docker, we can have a running Jenkins instance in a matter of seconds. 
 
-In your terminal, run: 
+In your terminal, first build a jenkins image with docker installed. Create a `Dockerfile` with the following:
+
+[source,]
+----
+FROM jenkins/jenkins:lts
+USER root
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg-agent \
+    software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add
+RUN add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/debian \
+   $(lsb_release -cs) \
+   stable"
+RUN apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io 
+EXPOSE 8080
+----
+
+From the same directory as your Dockerfile, build the image:
+[source,]
+----
+docker build -t jenkins:lts-docker .
+----
+
+[NOTE]
+====
+Running Jenkins as a docker container on a BAH managed machine requires specific certificates and tooling to be installed. A Dockerfile meeting these requirements can be built from the solutions-delivery-platform/bah-jenkins repo available internally.
+====
+
+Then, to start jenkins, run:
 
 (If running Docker for Windows, please refer to Important section below)
 
 [source,]
 ----
     docker run --name jenkins \
-    -v $(which docker):/usr/local/bin/docker \
     -v /var/run/docker.sock:/var/run/docker.sock \
     --privileged \
     --user root \
     -p 50000:50000 \
     -p 8080:8080 \
     -d \
-    jenkins/jenkins:lts
+    jenkins:lts-docker
 ----
 
 .Command Line Breakdown
@@ -30,9 +61,6 @@ In your terminal, run:
 
 | --name jenkins
 | Names the container being launched `jenkins`. This is done for ease of referencing it later.
-
-| -v $(which docker):/usr/local/bin/docker
-| Mounts the local docker executable to the Jenkins container, since docker is not installed in the container.
 
 | -v /var/run/docker.sock:/var/run/docker.sock
 | Mounts the local docker daemon socket to the Jenkins container.
@@ -65,7 +93,18 @@ If port 8080 is already in use by another process then this command will fail.  
 [IMPORTANT]
 ====
 Windows OS: When using Docker for Windows, use the following command to run the Jenkins container: 
-docker run --name jenkins -v /usr/local/bin/docker:/usr/bin/docker -v //var/run/docker.sock:/var/run/docker.sock --privileged --user root -p 50000:50000 -p 8080:8080 -d jenkins/jenkins:lts
+
+[source,]
+----
+    docker run --name jenkins \
+    -v //var/run/docker.sock:/var/run/docker.sock  \
+    --privileged \
+    --user root \
+    -p 50000:50000 \
+    -p 8080:8080 \
+    -d \
+    jenkins:lts-docker
+----
 
 You can run ``docker logs -f jenkins`` to see the Jenkins logs.  It will say "Jenkins is fully up and running" when Jenkins is ready.
 


### PR DESCRIPTION
# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
When going through the learning-labs I found docker commands were not able to be executed from Jenkins running locally. This appeared to be a compatibility mismatch been the docker binary installed on my osx machine, and the docker binary called by Jenkins.

Apparently, copying over the docker binary from the local environment into the Jenkins container during docker run used to work. This does not appear to work any more; maybe due to an update either in Jenkins or osx?

This issue is resolved via installing the docker binary for Debian onto the Jenkins image.

## Types of Changes

<!--- What types of changes does your code introduce? Change [ ] to [x] for all boxes that apply: -->

- [ ] Fixing spelling errors 
- [ ] Adding a new Learning Lab 
- [x] Updating content to improve clarity 
- [ ] This Pull Request does not contain changes to the static HTML in the ``docs`` directory 

